### PR TITLE
Feature/dispute proof

### DIFF
--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -297,11 +297,6 @@ contract Crosschain {
         uint256 disputeIndexStart,
         uint256 disputeIndexStop
     ) public returns (bool) {
-        require(
-            existingHeaders.length > blockOfInterestIndex &&
-                blockOfInterestIndex >= 0,
-            "Block of interest index is out of range"
-        );
         bytes32 blockOfInterestHash = hashHeader(
             existingHeaders[blockOfInterestIndex]
         );

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -204,14 +204,6 @@ contract Crosschain {
         return true;
     }
 
-    function hashProof(bytes32[4][] memory headers)
-        public
-        payable
-        returns (bytes32)
-    {
-        return sha256(abi.encodePacked(headers));
-    }
-
     function submitEventProof(
         bytes32[4][] memory headers,
         bytes32[] memory siblings,

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -18,7 +18,6 @@ contract Crosschain {
     struct Event {
         address payable author;
         uint256 expire;
-        bytes32 proofHash;
         bytes32 hashedProofHash;
     }
 
@@ -230,7 +229,7 @@ contract Crosschain {
             "The submission period has expired"
         );
         require(
-            events[hashedBlock].proofHash == 0,
+            events[hashedBlock].hashedProofHash == 0,
             "A proof with this evens exists"
         );
         require(
@@ -248,7 +247,6 @@ contract Crosschain {
             "Merkle verification failed"
         );
 
-        events[hashedBlock].proofHash = hashProof(headers);
         events[hashedBlock].hashedProofHash = sha256(
             abi.encodePacked(hashedHeaders)
         );

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -344,7 +344,7 @@ contract Crosschain {
                 disputeIndexStart,
                 disputeIndexStop
             ),
-            "Existing proof is valid at this index"
+            "Existing proof is valid in this range"
         );
 
         // If you reached this point, contesting was successful

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -364,32 +364,12 @@ contract Crosschain {
             "Wrong siblings"
         );
         require(
-            1 <= disputeIndexStart && disputeIndexStart < disputeIndexStop,
-            "Dispute start index out of range"
+            1 <= disputeIndex && disputeIndex < existingHeaders.length,
+            "Dispute index out of range"
         );
         require(
-            1 <= disputeIndexStop && disputeIndexStop <= existingHeaders.length,
-            "Dispute stop index out of range"
-        );
-
-        bytes32[] memory existingHeadersHashed = new bytes32[](
-            disputeIndexStop - disputeIndexStart + 1
-        );
-        for (uint256 i = 0; i < disputeIndexStop - disputeIndexStart + 1; i++) {
-            existingHeadersHashed[i] = hashHeader(
-                existingHeaders[i + disputeIndexStart]
-            );
-        }
-
-        require(
-            !validateInterlink(
-                existingHeaders,
-                existingHeadersHashed,
-                siblings,
-                disputeIndexStart,
-                disputeIndexStop
-            ),
-            "Existing proof is valid in this range"
+            !validateSingleInterlink(existingHeaders, siblings, disputeIndex),
+            "Existing proof is valid at this index"
         );
 
         // If you reached this point, contesting was successful

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -169,7 +169,6 @@ contract Crosschain {
 
     function findSiblingsOffset(
         bytes32[4][] memory headers,
-        bytes32[] memory siblings,
         uint256 proofIndex
     ) internal pure returns (uint256) {
         uint256 ptr;
@@ -193,7 +192,6 @@ contract Crosschain {
     ) internal pure returns (bool) {
         uint256 siblingsOffset = findSiblingsOffset(
             headers,
-            siblings,
             validateIndex
         );
 

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -330,11 +330,11 @@ contract Crosschain {
             "Block of interest exists in sub-chain"
         );
 
-        // TODO check hash of hashed existing. How do I do the following line from python
-        // require(
-        //     events[blockOfInterestHash].hashProofHash == hashProof(existingHeadersHash),
-        //     "Wrong existing proof"
-        // );
+        require(
+            events[blockOfInterestHash].hashedProofHash ==
+                sha256(abi.encodePacked(existingHeadersHashed)),
+            "Wrong existing proof"
+        );
 
         bytes32[] memory contestingHeadersHashed = new bytes32[](
             contestingHeaders.length

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -19,6 +19,7 @@ contract Crosschain {
         address payable author;
         uint256 expire;
         bytes32 proofHash;
+        bytes32 hashedProofHash;
     }
 
     // the block header hash.
@@ -165,14 +166,18 @@ contract Crosschain {
         return uint8(bytes1(b << 248));
     }
 
+    // This is ugly
+    bytes32 hashedProofHash;
+
     function validateInterlink(
         bytes32[4][] memory headers,
         bytes32[] memory siblings
-    ) internal pure returns (bool) {
+    ) internal returns (bool) {
         bytes32[] memory hashedHeaders = new bytes32[](headers.length);
         for (uint256 i = 0; i < headers.length; i++) {
             hashedHeaders[i] = hashHeader(headers[i]);
         }
+        hashedProofHash = sha256(abi.encodePacked(hashedHeaders));
         return validateInterlink(headers, hashedHeaders, siblings);
     }
 
@@ -253,6 +258,7 @@ contract Crosschain {
         );
 
         events[hashedBlock].proofHash = hashProof(headers);
+        events[hashedBlock].hashedProofHash = hashedProofHash;
         events[hashedBlock].expire = block.number + k;
         events[hashedBlock].author = msg.sender;
 

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -18,7 +18,9 @@ contract Crosschain {
     struct Event {
         address payable author;
         uint256 expire;
+        bytes32 proofHash;
         bytes32 hashedProofHash;
+        bytes32 siblingsHash;
     }
 
     // the block header hash.
@@ -241,9 +243,11 @@ contract Crosschain {
             hashedHeaders[i] = hashHeader(headers[i]);
         }
 
+        events[hashedBlock].proofHash = sha256(abi.encodePacked(headers));
         events[hashedBlock].hashedProofHash = sha256(
             abi.encodePacked(hashedHeaders)
         );
+        events[hashedBlock].siblingsHash = sha256(abi.encodePacked(siblings));
         events[hashedBlock].expire = block.number + k;
         events[hashedBlock].author = msg.sender;
 

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -218,7 +218,7 @@ contract Crosschain {
         bytes32[4][] memory headers,
         bytes32[] memory hashedHeaders,
         bytes32[] memory siblings
-    ) internal returns (bool) {
+    ) internal pure returns (bool) {
         uint256 ptr = 0; // Index of the current sibling
         for (uint256 i = 1; i < headers.length; i++) {
             // hold the 3rd and 4th least significant bytes

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -316,11 +316,11 @@ contract Crosschain {
             "Wrong siblings"
         );
         require(
-            1 <= disputeIndexStart && disputeIndexStart <= disputeIndexStop,
+            1 <= disputeIndexStart && disputeIndexStart < disputeIndexStop,
             "Dispute start index out of range"
         );
         require(
-            1 <= disputeIndexStop && disputeIndexStop < existingHeaders.length,
+            1 <= disputeIndexStop && disputeIndexStop <= existingHeaders.length,
             "Dispute stop index out of range"
         );
 

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -168,6 +168,24 @@ contract Crosschain {
     }
 
     function validateInterlink(
+    function findSiblingsOffset(
+        bytes32[4][] memory headers,
+        bytes32[] memory siblings,
+        uint256 proofIndex
+    ) internal pure returns (uint256) {
+        uint256 ptr;
+
+        for (uint256 i = 1; i < proofIndex; i++) {
+            // hold the 3rd and 4th least significant bytes
+            uint8 branchLength = b32ToUint8(
+                (headers[i][3] >> 8) & bytes32(uint256(0xff))
+            );
+            require(branchLength <= 5, "Branch length too big");
+            ptr += branchLength;
+        }
+
+        return ptr;
+    }
         bytes32[4][] memory headers,
         bytes32[] memory hashedHeaders,
         bytes32[] memory siblings,

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -167,7 +167,6 @@ contract Crosschain {
         return uint8(bytes1(b << 248));
     }
 
-    function validateInterlink(
     function findSiblingsOffset(
         bytes32[4][] memory headers,
         bytes32[] memory siblings,
@@ -216,6 +215,8 @@ contract Crosschain {
                 reversedSiblings
             );
     }
+
+    function validateInterlinks(
         bytes32[4][] memory headers,
         bytes32[] memory hashedHeaders,
         bytes32[] memory siblings,
@@ -342,8 +343,7 @@ contract Crosschain {
         bytes32[4][] memory existingHeaders,
         bytes32[] memory siblings,
         uint256 blockOfInterestIndex,
-        uint256 disputeIndexStart,
-        uint256 disputeIndexStop
+        uint256 disputeIndex
     ) public returns (bool) {
         bytes32 blockOfInterestHash = hashHeader(
             existingHeaders[blockOfInterestIndex]
@@ -441,7 +441,7 @@ contract Crosschain {
         }
 
         require(
-            validateInterlink(
+            validateInterlinks(
                 contestingHeaders,
                 contestingHeadersHashed,
                 contestingSiblings,

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -353,7 +353,6 @@ contract Crosschain {
         );
 
         require(
-            // TODO: Do we need contestingHeaders.length[x][] of contestingHeadersHased[x]
             existingHeadersHashed[lca] ==
                 contestingHeadersHashed[contestingHeaders.length - 1],
             "Wrong lca"

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -269,7 +269,7 @@ contract Crosschain {
 
     // If this will be expensive, check memory mapping
     // Check if all blocks of existing[lca+1:] are different from contesting[1:]
-    function allDifferent(
+    function disjointProofs(
         bytes32[] memory existing,
         bytes32[] memory contesting,
         uint256 lca
@@ -342,7 +342,7 @@ contract Crosschain {
         );
 
         require(
-            allDifferent(existingHeadersHashed, contestingHeadersHashed, lca),
+            disjointProofs(existingHeadersHashed, contestingHeadersHashed, lca),
             "Contesting proof[1:] is not different from existing[lca+1:]"
         );
 

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -186,6 +186,36 @@ contract Crosschain {
 
         return ptr;
     }
+
+    function validateSingleInterlink(
+        bytes32[4][] memory headers,
+        bytes32[] memory siblings,
+        uint256 validateIndex
+    ) internal pure returns (bool) {
+        uint256 siblingsOffset = findSiblingsOffset(
+            headers,
+            siblings,
+            validateIndex
+        );
+
+        uint8 branchLength = b32ToUint8(
+            (headers[validateIndex][3] >> 8) & bytes32(uint256(0xff))
+        );
+        uint8 merkleIndex = b32ToUint8(
+            (headers[validateIndex][3] >> 0) & bytes32(uint256(0xff))
+        );
+        bytes32[] memory reversedSiblings = new bytes32[](branchLength);
+        for (uint8 j = 0; j < branchLength; j++)
+            reversedSiblings[j] = siblings[siblingsOffset + j];
+
+        return
+            verifyMerkle(
+                headers[validateIndex - 1][0],
+                hashHeader(headers[validateIndex]),
+                merkleIndex,
+                reversedSiblings
+            );
+    }
         bytes32[4][] memory headers,
         bytes32[] memory hashedHeaders,
         bytes32[] memory siblings,

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -202,7 +202,7 @@ contract Crosschain {
             if (
                 !verifyMerkle(
                     headers[i - 1][0],
-                    hashedHeaders[i],
+                    hashedHeaders[i - startValidateIndex],
                     merkleIndex,
                     reversedSiblings
                 )
@@ -325,10 +325,12 @@ contract Crosschain {
         );
 
         bytes32[] memory existingHeadersHashed = new bytes32[](
-            existingHeaders.length
+            disputeIndexStop - disputeIndexStart + 1
         );
-        for (uint256 i = 0; i < existingHeadersHashed.length; i++) {
-            existingHeadersHashed[i] = hashHeader(existingHeaders[i]);
+        for (uint256 i = 0; i < disputeIndexStop - disputeIndexStart + 1; i++) {
+            existingHeadersHashed[i] = hashHeader(
+                existingHeaders[i + disputeIndexStart]
+            );
         }
 
         require(

--- a/experiment/contractNipopow.sol
+++ b/experiment/contractNipopow.sol
@@ -219,10 +219,8 @@ contract Crosschain {
     function validateInterlinks(
         bytes32[4][] memory headers,
         bytes32[] memory hashedHeaders,
-        bytes32[] memory siblings,
-        uint256 startValidateIndex,
-        uint256 endValidateIndex
-    ) internal pure returns (bool) {
+        bytes32[] memory siblings
+    ) internal returns (bool) {
         uint256 ptr = 0; // Index of the current sibling
         for (uint256 i = 1; i < headers.length; i++) {
             // hold the 3rd and 4th least significant bytes
@@ -242,16 +240,12 @@ contract Crosschain {
                 reversedSiblings[j] = siblings[ptr + j];
             ptr += branchLength;
 
-            // We only care to verify within our range
-            if (i < startValidateIndex || endValidateIndex < i) {
-                continue;
-            }
 
             // Verify the merkle tree proof
             if (
                 !verifyMerkle(
                     headers[i - 1][0],
-                    hashedHeaders[i - startValidateIndex],
+                    hashedHeaders[i],
                     merkleIndex,
                     reversedSiblings
                 )
@@ -424,9 +418,7 @@ contract Crosschain {
             validateInterlinks(
                 contestingHeaders,
                 contestingHeadersHashed,
-                contestingSiblings,
-                1,
-                contestingHeaders.length
+                contestingSiblings
             ),
             "Merkle verification failed"
         );

--- a/experiment/nipopow_verifier/tests/config.py
+++ b/experiment/nipopow_verifier/tests/config.py
@@ -25,7 +25,7 @@ errors = {
     "wrong lca": "Wrong lca",
     "same proofs": "Contesting proof[1:] is not different from existing[lca+1:]",
     "low score": "Existing proof has greater score",
-    "valid existing": "Existing proof is valid in this range",
+    "valid existing": "Existing proof is valid at this index",
 }
 
 

--- a/experiment/nipopow_verifier/tests/config.py
+++ b/experiment/nipopow_verifier/tests/config.py
@@ -25,6 +25,7 @@ errors = {
     "wrong lca": "Wrong lca",
     "same proofs": "Contesting proof[1:] is not different from existing[lca+1:]",
     "low score": "Existing proof has greater score",
+    "valid existing": "Existing proof is valid in this range",
 }
 
 

--- a/experiment/nipopow_verifier/tests/contract_api.py
+++ b/experiment/nipopow_verifier/tests/contract_api.py
@@ -72,6 +72,56 @@ def submit_event_proof(
     return {"result": res, "gas_used": receipt["gasUsed"], "debug": debug_events}
 
 
+def dispute_existing_proof(
+    interface,
+    existing,
+    block_of_interest_index,
+    invalid_index_start=None,
+    invalid_index_stop=None,
+    profile=True,
+):
+    """
+    Calls disputeExistingProof(existingHeaders, existingHeadersHash, siblings)
+    """
+
+    if invalid_index_start is None:
+        invalid_index_start = 1
+    if invalid_index_stop is None:
+        invalid_index_stop = existing.size
+
+    my_contract = interface.get_contract()
+    from_address = interface.w3.eth.accounts[0]
+    my_function = my_contract.functions.disputeExistingProof(
+        existing.headers,
+        existing.siblings,
+        block_of_interest_index,
+        invalid_index_start,
+        invalid_index_stop,
+    )
+
+    res = my_function.call({"from": from_address})
+
+    tx_hash = my_function.transact({"from": from_address})
+
+    receipt = interface.w3.eth.waitForTransactionReceipt(tx_hash)
+    try:
+        debug_events = my_contract.events.debug().processReceipt(receipt)
+    except Exception as ex:
+        debug_events = {}
+    if len(debug_events) > 0:
+        for e in debug_events:
+            log = dict(e)["args"]
+            print(log["tag"], "\t", log["value"])
+
+    if profile is True:
+        filename = str(int(time())) + ".txt"
+        interface.run_gas_profiler(profiler, tx_hash, filename)
+
+    print(receipt["gasUsed"])
+
+    return {"result": res, "gas_used": receipt["gasUsed"], "debug": debug_events}
+
+
 # bytes32[4][] memory existingHeaders,
 # uint256 lca,
 # bytes32[4][] memory contestingHeaders,

--- a/experiment/nipopow_verifier/tests/contract_api.py
+++ b/experiment/nipopow_verifier/tests/contract_api.py
@@ -73,30 +73,16 @@ def submit_event_proof(
 
 
 def dispute_existing_proof(
-    interface,
-    existing,
-    block_of_interest_index,
-    invalid_index_start=None,
-    invalid_index_stop=None,
-    profile=True,
+    interface, existing, block_of_interest_index, invalid_index, profile=True,
 ):
     """
     Calls disputeExistingProof(existingHeaders, existingHeadersHash, siblings)
     """
 
-    if invalid_index_start is None:
-        invalid_index_start = 1
-    if invalid_index_stop is None:
-        invalid_index_stop = existing.size
-
     my_contract = interface.get_contract()
     from_address = interface.w3.eth.accounts[0]
     my_function = my_contract.functions.disputeExistingProof(
-        existing.headers,
-        existing.siblings,
-        block_of_interest_index,
-        invalid_index_start,
-        invalid_index_stop,
+        existing.headers, existing.siblings, block_of_interest_index, invalid_index,
     )
 
     res = my_function.call({"from": from_address})

--- a/experiment/nipopow_verifier/tests/contract_api.py
+++ b/experiment/nipopow_verifier/tests/contract_api.py
@@ -57,7 +57,11 @@ def submit_event_proof(
     if len(debug_events) > 0:
         for e in debug_events:
             log = dict(e)["args"]
-            print(log["tag"], "\t", log["value"])
+            if isinstance(log["value"], bytes):
+                value = log["value"].hex()
+            else:
+                value = log["value"]
+            print(log["tag"], "\t", value)
 
     if profile is True:
         filename = str(int(time())) + ".txt"
@@ -93,7 +97,7 @@ def submit_contesting_proof_new(
         from_address = interface.w3.eth.accounts[0]
 
     my_function = my_contract.functions.submitContestingProof(
-        existing.headers,
+        existing.hashed_headers,
         lca,
         contesting.headers,
         contesting.siblings,

--- a/experiment/nipopow_verifier/tests/test_dispute_existing.py
+++ b/experiment/nipopow_verifier/tests/test_dispute_existing.py
@@ -20,7 +20,7 @@ from config import errors, extract_message_from_error, genesis
 import pytest
 
 
-backend = "geth"
+backend = "ganache"
 
 
 @pytest.fixture

--- a/experiment/nipopow_verifier/tests/test_dispute_existing.py
+++ b/experiment/nipopow_verifier/tests/test_dispute_existing.py
@@ -1,0 +1,95 @@
+"""
+run with
+$ pytest -v -s test_dispute_existing.py
+"""
+
+import sys
+
+sys.path.append("../tools/proof/")
+from proof import Proof
+from create_proof import ProofTool
+from edit_chain import change_interlink_hash
+
+from contract_api import (
+    make_interface,
+    submit_event_proof,
+    dispute_existing_proof,
+)
+from config import errors, extract_message_from_error, genesis
+
+import pytest
+
+
+backend = "geth"
+
+
+@pytest.fixture
+def init_environment():
+    pass
+
+
+@pytest.fixture(scope="session", autouse=True)
+def finish_session(request):
+    """
+    This runs after every test
+    """
+
+    yield
+    # you can access the session from the injected 'request':
+    session = request.session
+    interface = make_interface(backend)
+    interface.end()
+
+
+def test_dispute_valid(init_environment):
+    """
+    Try to dispute valid proof
+    """
+
+    block_of_interest_index = 0
+    pt = ProofTool("../data/proofs/")
+    proof = Proof()
+    proof.set(pt.fetch_proof(500000))
+
+    interface = make_interface(backend)
+
+    res = submit_event_proof(interface, proof, block_of_interest_index, profile=True)
+
+    assert res["result"] == True
+
+    with pytest.raises(Exception) as ex:
+        res = dispute_existing_proof(
+            interface, proof, block_of_interest_index, 1, proof.size - 1, profile=True
+        )
+    assert extract_message_from_error(ex) == errors["valid existing"]
+
+
+def test_dispute_invalid(init_environment):
+    """
+    Try to dispute valid proof
+    """
+
+    interface = make_interface(backend)
+    block_of_interest_index = 0
+    pt = ProofTool("../data/proofs/")
+    original_proof = pt.fetch_proof(500)
+
+    invalid_index = int(len(original_proof) / 2)
+    print("invalid index:", invalid_index)
+    invalid_proof = Proof()
+    invalid_proof.set(change_interlink_hash(original_proof, invalid_index))
+
+    res = submit_event_proof(
+        interface, invalid_proof, block_of_interest_index, profile=True
+    )
+    assert res["result"] == True
+
+    res = dispute_existing_proof(
+        interface,
+        invalid_proof,
+        block_of_interest_index,
+        invalid_index_start=invalid_index,
+        invalid_index_stop=invalid_index,
+        profile=True,
+    )
+    assert res["result"] == True

--- a/experiment/nipopow_verifier/tests/test_dispute_existing.py
+++ b/experiment/nipopow_verifier/tests/test_dispute_existing.py
@@ -21,11 +21,15 @@ import pytest
 
 
 backend = "ganache"
+proof = Proof()
 
 
 @pytest.fixture
 def init_environment():
-    pass
+    global backend
+    global proof
+    pt = ProofTool("../data/proofs/")
+    proof.set(pt.fetch_proof(500))
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -47,14 +51,8 @@ def test_dispute_valid(init_environment):
     """
 
     block_of_interest_index = 0
-    pt = ProofTool("../data/proofs/")
-    proof = Proof()
-    proof.set(pt.fetch_proof(500))
-
     interface = make_interface(backend)
-
     res = submit_event_proof(interface, proof, block_of_interest_index, profile=True)
-
     assert res["result"] == True
 
     with pytest.raises(Exception) as ex:
@@ -69,15 +67,12 @@ def test_dispute_invalid(init_environment):
     Try to dispute valid proof
     """
 
-    interface = make_interface(backend)
     block_of_interest_index = 0
-    pt = ProofTool("../data/proofs/")
-    original_proof = pt.fetch_proof(500)
+    interface = make_interface(backend)
+    invalid_index = int(proof.size / 2)
 
-    invalid_index = int(len(original_proof) / 2)
-    print("invalid index:", invalid_index)
     invalid_proof = Proof()
-    invalid_proof.set(change_interlink_hash(original_proof, invalid_index))
+    invalid_proof.set(change_interlink_hash(proof.proof, invalid_index))
 
     res = submit_event_proof(
         interface, invalid_proof, block_of_interest_index, profile=True

--- a/experiment/nipopow_verifier/tests/test_dispute_existing.py
+++ b/experiment/nipopow_verifier/tests/test_dispute_existing.py
@@ -49,7 +49,7 @@ def test_dispute_valid(init_environment):
     block_of_interest_index = 0
     pt = ProofTool("../data/proofs/")
     proof = Proof()
-    proof.set(pt.fetch_proof(500000))
+    proof.set(pt.fetch_proof(500))
 
     interface = make_interface(backend)
 

--- a/experiment/nipopow_verifier/tests/test_dispute_existing.py
+++ b/experiment/nipopow_verifier/tests/test_dispute_existing.py
@@ -89,7 +89,7 @@ def test_dispute_invalid(init_environment):
         invalid_proof,
         block_of_interest_index,
         invalid_index_start=invalid_index,
-        invalid_index_stop=invalid_index,
+        invalid_index_stop=invalid_index + 1,
         profile=True,
     )
     assert res["result"] == True

--- a/experiment/nipopow_verifier/tests/test_dispute_existing.py
+++ b/experiment/nipopow_verifier/tests/test_dispute_existing.py
@@ -57,7 +57,7 @@ def test_dispute_valid(init_environment):
 
     with pytest.raises(Exception) as ex:
         res = dispute_existing_proof(
-            interface, proof, block_of_interest_index, 1, proof.size - 1, profile=True
+            interface, proof, block_of_interest_index, 1, profile=True
         )
     assert extract_message_from_error(ex) == errors["valid existing"]
 
@@ -80,11 +80,6 @@ def test_dispute_invalid(init_environment):
     assert res["result"] == True
 
     res = dispute_existing_proof(
-        interface,
-        invalid_proof,
-        block_of_interest_index,
-        invalid_index_start=invalid_index,
-        invalid_index_stop=invalid_index + 1,
-        profile=True,
+        interface, invalid_proof, block_of_interest_index, invalid_index, profile=True,
     )
     assert res["result"] == True

--- a/experiment/nipopow_verifier/tools/proof/proof.py
+++ b/experiment/nipopow_verifier/tools/proof/proof.py
@@ -3,6 +3,7 @@ Store proofs to objects
 proof = Proof()
 proof.set(import_proof('myproof'))
 """
+from bitcoin.core import Hash
 
 
 class Proof:
@@ -16,6 +17,7 @@ class Proof:
         self.name = ""
         self.proof = []
         self.headers = []
+        self.hashed_headers = []
         self.siblings = []
         self.size = 0
 
@@ -68,4 +70,8 @@ class Proof:
         self.proof = proof
         self.name = proof_name
         self.headers, self.siblings = self.extract_headers_siblings(self.proof)
+
+        for i in range(len(self.headers)):
+            self.hashed_headers.append(Hash(self.proof[i][0]))
+
         self.size = len(self.proof)


### PR DESCRIPTION
# tl;dr
Submit proof does not need to be verified on-chain anymore

# Functionality
There are two reasons a proof should be rejected: 
1. existing proof is not valid
2. existing proof is valid, but there is a larger, honest proof that does not include the claimed predicate

Previously, the first functionality was included in the submit-phase. Submit- and dispute-phases can be decoupled in order to have a more gas-efficient and more clear solution. When a proof is submitted, another party has the option to dispute its validity. During dispute-phase, the existing proof is validated applying a merkle-proof validation at each block. This removes the proof validation from the submit-proof phase.

# Further optimizations
Further optimizations can be made. The dispute operation can be restricted to a slice of the existing proof. The rationale is that once an invalid proof has been observed by a party, they only need to prove that the existing chain is flawed at a certain index of the proof which is an equivalent to the statement that the entire proof is invalid. The party that chooses to dispute an existing proof indicates the index in which the existing proof is invalid, resulting to constant time verification of the existing proof. Of course, one can chose to dispute the full range of the existing proof, which is no longer a constant operation.